### PR TITLE
Add Runtime domain

### DIFF
--- a/cproto/resources/protocol.json
+++ b/cproto/resources/protocol.json
@@ -7,6 +7,10 @@
             {
                 "name": "evaluate",
                 "description": "Evaluates expression on global object."
+            },
+            {
+                "name": "getProperties",
+                "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
             }
         ]
       },{

--- a/cproto/resources/protocol.json
+++ b/cproto/resources/protocol.json
@@ -1,6 +1,15 @@
 {
     "version": { "major": "1", "minor": "2" },
     "domains": [{
+        "domain": "Runtime",
+        "types": [],
+        "commands": [
+            {
+                "name": "evaluate",
+                "description": "Evaluates expression on global object."
+            }
+        ]
+      },{
         "domain": "Inspector",
         "experimental": true,
         "types": [],


### PR DESCRIPTION
Runtime domain "evaluate" allow you to run javascript on the remote page.
example of usage

Simple example getting the text of the title HTML tag of github homepage using **Runtime.evaluate** returning a single value
```
from cproto import CProto

cp = CProto(host='127.0.0.1', port=9222)
cp.Page.navigate(url='https://github.com')
res = cp.Runtime.evaluate(expression='document.querySelector("title").text')
print(res.get("result").get("result").get("value"))
"The world's leading software development platform · GitHub"
```

More complex example using **Runtime.getProperties** on a returned array to get the href of all links on github homepage.

```
from cproto import CProto

cp = CProto(host='127.0.0.1', port=9222)
cp.Page.navigate(url='https://github.com')

res = cp.Runtime.evaluate(expression="""(function() {
    let links = []
    document.querySelectorAll('a:not([value=""])').forEach(function(e){links.push(e.href)})
    return links
})()""")
res = cp.Runtime.getProperties(objectId=res.get("result").get("result").get("objectId"), returnByValue=True)

for link in res.get("result").get("result"):
    if link.get("enumerable"):
        print(link.get("value").get("value"))
```

